### PR TITLE
:wrench: Laravel12 compatible!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.idea/
 /composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/queue": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/bus": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "aws/aws-sdk-php": "~3.0"
+        "php": "^8.2|^8.3|^8.4",
+        "illuminate/support": "^12.0",
+        "illuminate/queue": "^12.0",
+        "illuminate/bus": "^12.0",
+        "aws/aws-sdk-php": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*|^9.5.10|^10.0|^11.0"

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,17 @@
         "aws/aws-sdk-php": "^3.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*|^9.5.10|^10.0|^11.0"
+        "phpunit/phpunit": "^11.0",
+        "mockery/mockery": "^1.6"
     },
     "autoload": {
         "psr-4": {
             "Dusterio\\PlainSqs\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
         }
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         failOnWarning="true"
+         failOnNotice="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <testsuites>
         <testsuite name="PlainSqs library Test Suite">
             <directory suffix=".php">tests/PlainSqs/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Jobs/CustomPlainSqsJob.php
+++ b/src/Jobs/CustomPlainSqsJob.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Dusterio\PlainSqs\Jobs;
+
+use Illuminate\Queue\Jobs\SqsJob;
+
+class CustomPlainSqsJob extends SqsJob
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolveQueuedJobClass()
+    {
+        return parent::resolveQueuedJobClass();
+    }
+}

--- a/src/Jobs/DispatcherJob.php
+++ b/src/Jobs/DispatcherJob.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Config;
 
 class DispatcherJob implements ShouldQueue
 {
@@ -37,7 +38,7 @@ class DispatcherJob implements ShouldQueue
     {
         if (! $this->isPlain()) {
             return [
-                'job' => app('config')->get('sqs-plain.default-handler'),
+                'job' => Config::get('sqs-plain.default-handler'),
                 'data' => $this->data
             ];
         }

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -15,16 +15,16 @@ class Queue extends SqsQueue
 {
     /**
      * Create a payload string from the given job and data.
-     *
-     * @param  string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
-     * @return string
+     * @param $job
+     * @param $queue
+     * @param $data
+     * @param $delay
+     * @return false|string
      */
-    protected function createPayload($job, $data = '', $queue = null)
+    protected function createPayload($job, $queue = null, $data = '', $delay = null)
     {
         if (!$job instanceof DispatcherJob) {
-            return parent::createPayload($job, $data, $queue);
+            return parent::createPayload($job, $queue, $data, $delay);
         }
 
         $handlerJob = $this->getClass($queue) . '@handle';
@@ -72,14 +72,7 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            if (preg_match(
-                '/(5\.[4-8]\..*)|(6\.[0-9]*\..*)|(7\.[0-9]*\..*)|(8\.[0-9]*\..*)|(9\.[0-9]*\..*)|(10\.[0-9]*\..*)|(11\.[0-9]*\..*)|(12\.[0-9]*\..*)/',
-                $this->container->version())
-            ) {
-                return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
-            }
-
-            return new SqsJob($this->container, $this->sqs, $queue, $response);
+            return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
         }
     }
 

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -3,6 +3,7 @@
 namespace Dusterio\PlainSqs\Sqs;
 
 use Dusterio\PlainSqs\Jobs\DispatcherJob;
+use Illuminate\Queue\InvalidPayloadException;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Queue\Jobs\SqsJob;
@@ -16,7 +17,7 @@ class Queue extends SqsQueue
 {
     /**
      * @inheritDoc
-     * @throws JsonException
+     * @throws InvalidPayloadException|JsonException
      */
     protected function createPayload($job, $queue = null, $data = '', $delay = null)
     {

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -43,7 +43,8 @@ class Queue extends SqsQueue
             return Config::get('sqs-plain.default-handler');
         }
 
-        $queue = end(explode('/', $queue));
+        $array = explode('/', $queue);
+        $queue = end($array);
 
         if (array_key_exists($queue, Config::get('sqs-plain.handlers'))) {
             return Config::get('sqs-plain.handlers')[$queue];

--- a/tests/FullAccessWrapper.php
+++ b/tests/FullAccessWrapper.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use ErrorException;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * for private, protected method, property access
+ */
+readonly class FullAccessWrapper
+{
+    /** @var ReflectionClass reflection */
+    private ReflectionClass $reflection;
+
+    /**
+     * @param object $targetInstance
+     */
+    public function __construct(private object $targetInstance)
+    {
+        $this->reflection = new ReflectionClass($targetInstance);
+    }
+
+    /**
+     * @param string $methodName
+     * @param array<int,mixed> $args
+     * @return mixed
+     * @throws ReflectionException
+     */
+    public function __call(string $methodName, array $args)
+    {
+        $method = $this->reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($this->targetInstance, $args);
+    }
+
+    /**
+     * @param string $name
+     * @return mixed|void
+     * @throws ReflectionException
+     * @throws ErrorException
+     */
+    public function __get(string $name)
+    {
+        if ($this->reflection->hasProperty($name)) {
+            $property = $this->reflection->getProperty($name);
+            $property->setAccessible(true);
+
+            return $property->getValue($this->targetInstance);
+        }
+
+        throw new ErrorException("ErrorException : Undefined property: $name");
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     * @throws ErrorException
+     * @throws ReflectionException
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        if ($this->reflection->hasProperty($name)) {
+            $property = $this->reflection->getProperty($name);
+
+            $property->setValue($this->targetInstance, $value);
+        } else {
+            throw new ErrorException("ErrorException : Undefined property: $name");
+        }
+    }
+
+    /**
+     * Get reflection class
+     * @return Object
+     */
+    public function getInstance(): object
+    {
+        return $this->targetInstance;
+    }
+}


### PR DESCRIPTION
# problem
createPayload method sould be same as parent. error is thrwon on Laravel12.

# tobe
- parameter order of createPayload method should be compatible.
- Laravel 12 compatible.

# todo
- drop support ~ laravel11 and ~php81
- add laravel12 support
  error message
  ```
  {
      "class": "Symfony\\Component\\ErrorHandler\\Error\\FatalError",
      "message": "Class Illuminate\\Queue\\Jobs\\SqsJob contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\\Contracts\\Queue\\Job::resolveQueuedJobClass)",
      "code": 0,
      "file": "/var/www/XXXX/vendor/laravel/framework/src/Illuminate/Queue/Jobs/SqsJob.php:9"
  }
  ```

  add class src/Jobs/CustomPlainSqsJob.php.
  ```
  public function resolveQueuedJobClass()
    {
        return JobName::resolveClassName($this->getName(), $this->payload());
    }
  ```
- add test